### PR TITLE
[DRAFT] Enhancement/threat actor group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 dist/
-
+test/.t.env

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This is a TypeScript library for interacting with OpenCTI
 
 ## Testing
 
+Copy the test environment file and fill in the values:
+
+```bash
+cp ./test/.t.env.example ./test/.t.env
+```
+
 To test this package in an external project:
 
 1. Build the package locally:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "module",
     "scripts": {
         "build": "rm -rf dist/; tsc",
-        "test": "mocha",
+        "test": "mocha -r dotenv/config dotenv_config_path=./test/.t.env",
         "prepublishOnly": "npm run build",
         "prettier:check": "npx prettier -c \"**/*.{js,ts,md,json,yml,yaml}\"",
         "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,json,yml,yaml}\""
@@ -36,6 +36,7 @@
         "@types/eventsource": "^1.1.15",
         "@types/node": "^20.12.7",
         "@types/uuid": "^10.0.0",
+        "dotenv": "^16.4.5",
         "mocha": "^10.7.3",
         "prettier": "^3.3.3",
         "tsx": "^4.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       mocha:
         specifier: ^10.7.3
         version: 10.7.3
@@ -352,6 +355,10 @@ packages:
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -899,6 +906,8 @@ snapshots:
   decamelize@4.0.0: {}
 
   diff@5.2.0: {}
+
+  dotenv@16.4.5: {}
 
   emoji-regex@8.0.0: {}
 

--- a/src/graphql/fragments.ts
+++ b/src/graphql/fragments.ts
@@ -1172,6 +1172,290 @@ export const ThreatActorGroupLocations_locations = gql`
 `;
 //#endregion
 
+//#region
+export const ThreatActorIndividualCardFragment = gql`
+  fragment ThreatActorIndividualCard_node on ThreatActorIndividual {
+    id
+    name
+    aliases
+    description
+    created
+    modified
+    entity_type
+    threat_actor_types
+    sophistication
+    resource_level
+    creators {
+      id
+      name
+    }
+    avatar {
+      id
+      name
+    }
+    status {
+      id
+      template {
+        id
+        name
+        color
+      }
+    }
+    objectLabel {
+      id
+      value
+      color
+    }
+    objectMarking {
+      id
+      definition_type
+      definition
+      x_opencti_order
+      x_opencti_color
+    }
+    targetedCountries: stixCoreRelationships(
+      relationship_type: "targets"
+      toTypes: ["Country"]
+      first: 10
+      orderBy: created_at
+      orderMode: desc
+    ) {
+      edges {
+        node {
+          to {
+            ... on Country {
+              name
+            }
+          }
+        }
+      }
+    }
+    countryFlag: stixCoreRelationships(
+      relationship_type: "located-at"
+      toTypes: ["Country"]
+      first: 1
+      orderBy: created_at
+      orderMode: desc
+    ) {
+      edges {
+        node {
+          to {
+            ... on Country {
+              name
+              x_opencti_aliases
+            }
+          }
+        }
+      }
+    }
+    targetedSectors: stixCoreRelationships(
+      relationship_type: "targets"
+      toTypes: ["Sector"]
+      first: 10
+      orderBy: created_at
+      orderMode: desc
+    ) {
+      edges {
+        node {
+          to {
+            ... on Sector {
+              name
+            }
+          }
+        }
+      }
+    }
+    usedMalware: stixCoreRelationships(
+      relationship_type: "uses"
+      toTypes: ["Malware"]
+      first: 10
+      orderBy: created_at
+      orderMode: desc
+    ) {
+      edges {
+        node {
+          to {
+            ... on Malware {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const ThreatActorIndividual_ThreatActorIndividual = gql`
+  fragment ThreatActorIndividual_ThreatActorIndividual on ThreatActorIndividual {
+    id
+    standard_id
+    entity_type
+    x_opencti_stix_ids
+    spec_version
+    revoked
+    confidence
+    created
+    modified
+    created_at
+    updated_at
+    createdBy {
+      ... on Identity {
+        id
+        name
+        entity_type
+        x_opencti_reliability
+      }
+    }
+    creators {
+      id
+      name
+    }
+    objectMarking {
+      id
+      definition
+      definition_type
+      definition
+      x_opencti_order
+      x_opencti_color
+    }
+    objectLabel {
+      id
+      value
+      color
+    }
+    name
+    aliases
+    status {
+      id
+      order
+      template {
+        name
+        color
+      }
+    }
+    workflowEnabled
+    eye_color
+    hair_color
+    height {
+      date_seen
+      measure
+    }
+    weight {
+      date_seen
+      measure
+    }
+    date_of_birth
+    gender
+    marital_status
+    job_title
+    bornIn {
+      name
+    }
+    ethnicity {
+      name
+    }
+    stixCoreRelationships {
+      edges {
+        node {
+          relationship_type
+          to {
+            ... on Country {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+    ...ThreatActorIndividualDetails_ThreatActorIndividual
+  }
+`;
+
+export const ThreatActorIndividualKnowledge_ThreatActorIndividual = gql`
+  fragment ThreatActorIndividualKnowledge_ThreatActorIndividual on ThreatActorIndividual {
+    id
+    name
+    aliases
+    first_seen
+    last_seen
+  }
+`;
+
+export const ThreatActorIndividualDetails_ThreatActorIndividual = gql`
+  fragment ThreatActorIndividualDetails_ThreatActorIndividual on ThreatActorIndividual
+  {
+    id
+    first_seen
+    last_seen
+    description
+    threat_actor_types
+    sophistication
+    resource_level
+    personal_motivations
+    primary_motivation
+    secondary_motivations
+    goals
+    roles
+    stixCoreRelationships {
+      edges {
+        node {
+          id
+          relationship_type
+          to {
+            ... on Individual {
+              id
+              name
+            }
+            ... on Persona {
+              id
+              persona_name
+              persona_type
+            }
+          }
+        }
+      }
+    }
+    images: importFiles(prefixMimeType: "image/") {
+      edges {
+        node {
+          id
+          name
+          metaData {
+            mimetype
+            order
+            inCarousel
+            description
+          }
+        }
+      }
+    }
+    ...ThreatActorIndividualLocations_locations
+  }
+`;
+
+export const ThreatActorIndividualLocations_locations = gql`
+    fragment ThreatActorIndividualLocations_locations on ThreatActorIndividual {
+        id
+        name
+        parent_types
+        entity_type
+        locations {
+            edges {
+                types
+                node {
+                    id
+                    parent_types
+                    entity_type
+                    name
+                    x_opencti_aliases
+                    description
+                }
+            }
+        }
+    }
+`;
+//#endregion
+
 //#region individuals
 export const IndividualDetails_individual = gql`
     fragment IndividualDetails_individual on Individual {

--- a/src/graphql/fragments.ts
+++ b/src/graphql/fragments.ts
@@ -1057,6 +1057,121 @@ export const ImportContent_connectorsImport = gql`
     }
 `;
 
+//#region threatactorgroup
+export const ThreatActorGroup_ThreatActorGroup = gql`
+    fragment ThreatActorGroup_ThreatActorGroup on ThreatActorGroup {
+        id
+        standard_id
+        entity_type
+        x_opencti_stix_ids
+        spec_version
+        revoked
+        confidence
+        created
+        modified
+        created_at
+        updated_at
+        createdBy {
+        ... on Identity {
+            id
+            name
+            entity_type
+            x_opencti_reliability
+        }
+        }
+        creators {
+        id
+        name
+        }
+        objectMarking {
+        id
+        definition
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+        }
+        objectLabel {
+        id
+        value
+        color
+        }
+        name
+        aliases
+        status {
+        id
+        order
+        template {
+            name
+            color
+        }
+        }
+        workflowEnabled
+        ...ThreatActorGroupDetails_ThreatActorGroup
+    }
+`;
+export const ThreatActorGroupKnowledge_ThreatActorGroup = gql`
+    fragment ThreatActorGroupKnowledge_ThreatActorGroup on ThreatActorGroup {
+        id
+        name
+        aliases
+        first_seen
+        last_seen
+    }
+`;
+export const ThreatActorGroupDetails_ThreatActorGroup = gql`
+    fragment ThreatActorGroupDetails_ThreatActorGroup on ThreatActorGroup {
+        id
+        first_seen
+        last_seen
+        description
+        threat_actor_types
+        sophistication
+        resource_level
+        primary_motivation
+        secondary_motivations
+        goals
+        roles
+        images: importFiles(prefixMimeType: "image/") {
+        edges {
+            node {
+            id
+            name
+            metaData {
+                mimetype
+                order
+                inCarousel
+                description
+            }
+            }
+        }
+        }
+        ...ThreatActorGroupLocations_locations
+    }
+`;
+export const ThreatActorGroupLocations_locations = gql`
+    fragment ThreatActorGroupLocations_locations on ThreatActorGroup {
+        id
+        name
+        parent_types
+        entity_type
+        locations {
+        edges {
+            types
+            node {
+            id
+            parent_types
+            entity_type
+            name
+            x_opencti_aliases
+            description
+            }
+        }
+        }
+    }
+`;
+//#endregion
+
 //#region individuals
 export const IndividualDetails_individual = gql`
     fragment IndividualDetails_individual on Individual {

--- a/src/graphql/importedQueries.ts
+++ b/src/graphql/importedQueries.ts
@@ -833,6 +833,14 @@ export const ThreatGroupCreationMutation = gql`
     }
 `;
 
+export const ThreatActorGroupPopoverDeletionMutation = gql`
+    mutation ThreatActorGroupPopoverDeletionMutation($id: ID!) {
+        threatActorGroupEdit(id: $id) {
+            delete
+        }
+    }
+`;
+
 export const IndividualCreationMutation = gql`
     mutation IndividualCreationMutation($input: IndividualAddInput!) {
         individualAdd(input: $input) {

--- a/src/graphql/importedQueries.ts
+++ b/src/graphql/importedQueries.ts
@@ -841,6 +841,52 @@ export const ThreatActorGroupPopoverDeletionMutation = gql`
     }
 `;
 
+export const ThreatActorIndividualCreationMutation = gql`
+    mutation ThreatActorIndividualCreationMutation(
+        $input: ThreatActorIndividualAddInput!
+    ) {
+        threatActorIndividualAdd(input: $input) {
+            id
+            name
+            description
+            entity_type
+            parent_types
+            ...ThreatActorIndividualCard_node
+        }
+    }
+`;
+
+export const RootThreatActorIndividualQuery = gql`
+  query RootThreatActorIndividualQuery($id: String!) {
+    threatActorIndividual(id: $id) {
+      id
+      standard_id
+      entity_type
+      name
+      aliases
+      x_opencti_graph_data
+      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
+        label
+        value
+      }
+      ...ThreatActorIndividual_ThreatActorIndividual
+      ...ThreatActorIndividualKnowledge_ThreatActorIndividual
+      ...FileImportViewer_entity
+      ...FileExportViewer_entity
+      ...FileExternalReferencesViewer_entity
+      ...WorkbenchFileViewer_entity
+      ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
+    }
+    connectorsForExport {
+      ...FileManager_connectorsExport
+    }
+    connectorsForImport {
+      ...FileManager_connectorsImport
+    }
+  }
+`;
+
 export const IndividualCreationMutation = gql`
     mutation IndividualCreationMutation($input: IndividualAddInput!) {
         individualAdd(input: $input) {

--- a/src/graphql/importedQueries.ts
+++ b/src/graphql/importedQueries.ts
@@ -758,6 +758,37 @@ export const ProfileQuery = gql`
     }
 `;
 
+export const RootThreatActorGroupQuery = gql`
+  query RootThreatActorGroupQuery($id: String!) {
+    threatActorGroup(id: $id) {
+      id
+      standard_id
+      entity_type
+      name
+      aliases
+      x_opencti_graph_data
+      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
+        label
+        value
+      }
+      ...ThreatActorGroup_ThreatActorGroup
+      ...ThreatActorGroupKnowledge_ThreatActorGroup
+      ...FileImportViewer_entity
+      ...FileExportViewer_entity
+      ...FileExternalReferencesViewer_entity
+      ...WorkbenchFileViewer_entity
+      ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
+    }
+    connectorsForImport {
+      ...FileManager_connectorsImport
+    }
+    connectorsForExport {
+      ...FileManager_connectorsExport
+    }
+  }
+`;
+
 export const RootIndividualQuery = gql`
     query RootIndividualQuery($id: String!) {
         individual(id: $id) {
@@ -785,6 +816,19 @@ export const RootIndividualQuery = gql`
         connectorsForExport {
             ...FileManager_connectorsExport
             id
+        }
+    }
+`;
+
+export const ThreatGroupCreationMutation = gql`
+    mutation ThreatActorGroupCreationMutation($input: ThreatActorGroupAddInput!) {
+        threatActorGroupAdd(input: $input) {
+            id
+            standard_id
+            name
+            description
+            entity_type
+            parent_types
         }
     }
 `;

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -11,6 +11,8 @@ export type Incremental<T> = T | { [P in keyof T]?: P extends " $fragmentName" |
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 
+import { ThreatActorTypes } from "../types.js";
+
 export type Scalars = {
     ID: { input: string; output: string };
     String: { input: string; output: string };
@@ -152,6 +154,7 @@ export type ThreatGroupAddInput = {
     description?: InputMaybe<Scalars["String"]["input"]>;
     confidence?: InputMaybe<Scalars["Int"]["input"]>;
     objectMarking?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+    threat_actor_types?: ThreatActorTypes[]
 }
 
 export type IndividualAddInput = {

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -149,6 +149,14 @@ export enum IdentityType {
     System = "System",
 }
 
+export type ThreatIndividualAddInput = {
+    name: Scalars["String"]["input"];
+    description?: InputMaybe<Scalars["String"]["input"]>;
+    confidence?: InputMaybe<Scalars["Int"]["input"]>;
+    objectMarking?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+    threat_actor_types?: ThreatActorTypes[]
+}
+
 export type ThreatGroupAddInput = {
     name: Scalars["String"]["input"];
     description?: InputMaybe<Scalars["String"]["input"]>;

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -147,6 +147,13 @@ export enum IdentityType {
     System = "System",
 }
 
+export type ThreatGroupAddInput = {
+    name: Scalars["String"]["input"];
+    description?: InputMaybe<Scalars["String"]["input"]>;
+    confidence?: InputMaybe<Scalars["Int"]["input"]>;
+    objectMarking?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+}
+
 export type IndividualAddInput = {
     clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
     confidence?: InputMaybe<Scalars["Int"]["input"]>;

--- a/src/opencti.ts
+++ b/src/opencti.ts
@@ -34,6 +34,11 @@ import {
     ThreatActorGroupKnowledge_ThreatActorGroup,
     ThreatActorGroupDetails_ThreatActorGroup,
     ThreatActorGroupLocations_locations,
+    ThreatActorIndividualCardFragment,
+    ThreatActorIndividual_ThreatActorIndividual,
+    ThreatActorIndividualKnowledge_ThreatActorIndividual,
+    ThreatActorIndividualDetails_ThreatActorIndividual,
+    ThreatActorIndividualLocations_locations,
     Individual_individual,
     IndividualDetails_individual,
     IndividualKnowledge_individual,
@@ -72,6 +77,7 @@ import {
     IndicatorObservablePopoverDeletionMutation,
     IndicatorPopoverDeletionMutation,
     ThreatGroupCreationMutation,
+    ThreatActorIndividualCreationMutation,
     ThreatActorGroupPopoverDeletionMutation,
     IndividualCreationMutation,
     IndividualPopoverDeletionMutation,
@@ -84,6 +90,7 @@ import {
     RootIncidentQuery,
     RootIndicatorQuery,
     RootThreatActorGroupQuery,
+    RootThreatActorIndividualQuery,
     RootIndividualQuery,
     RootPrivateQuery,
     RootStixCyberObservableQuery,
@@ -145,6 +152,7 @@ import {
     StixCyberObservableAddInput,
     StixRef,
     Vocabulary,
+    ThreatIndividual,
 } from "./types.js";
 import { sleep } from "./utils.js";
 
@@ -189,6 +197,12 @@ export class OpenCTIClient {
                     ThreatActorGroupKnowledge_ThreatActorGroup,
                     ThreatActorGroupDetails_ThreatActorGroup,
                     ThreatActorGroupLocations_locations,
+
+                    ThreatActorIndividualCardFragment,
+                    ThreatActorIndividual_ThreatActorIndividual,
+                    ThreatActorIndividualKnowledge_ThreatActorIndividual,
+                    ThreatActorIndividualDetails_ThreatActorIndividual,
+                    ThreatActorIndividualLocations_locations,
 
                     Individual_individual,
                     IndividualDetails_individual,
@@ -750,6 +764,28 @@ export class OpenCTIClient {
         });
 
         return this.assertMutateResult(result).threatActorGroupEdit.delete;
+    }
+
+    public async createThreatIndividual(input: ThreatIndividualAddInput): Promise<ThreatIndividual> {
+        const result = await this.client.mutate<{ threatActorIndividualAdd: ThreatIndividual }>({
+            mutation: ThreatActorIndividualCreationMutation,
+            variables: {
+                input: input,
+            },
+        });
+
+        return this.assertMutateResult(result).threatActorIndividualAdd;
+    }
+
+    public async getThreatIndividual(id: StixRef): Promise<ThreatIndividual | null> {
+        const result = await this.client.query<{ threatActorIndividual: ThreatIndividual | null }>({
+            query: RootThreatActorIndividualQuery,
+            variables: {
+                id: id,
+            },
+        });
+
+        return this.assertQueryResult(result).threatActorIndividual;
     }
 
     public async getIndividual(id: StixRef): Promise<Individual | null> {

--- a/src/opencti.ts
+++ b/src/opencti.ts
@@ -30,6 +30,10 @@ import {
     IndicatorEditionOverview_indicator,
     IndicatorLine_node,
     IndicatorObservables_indicator,
+    ThreatActorGroup_ThreatActorGroup,
+    ThreatActorGroupKnowledge_ThreatActorGroup,
+    ThreatActorGroupDetails_ThreatActorGroup,
+    ThreatActorGroupLocations_locations,
     Individual_individual,
     IndividualDetails_individual,
     IndividualKnowledge_individual,
@@ -67,6 +71,7 @@ import {
     IndicatorEditionOverviewRelationDeleteMutation,
     IndicatorObservablePopoverDeletionMutation,
     IndicatorPopoverDeletionMutation,
+    ThreatGroupCreationMutation,
     IndividualCreationMutation,
     IndividualPopoverDeletionMutation,
     LabelsQuerySearchQuery,
@@ -77,6 +82,7 @@ import {
     RootCaseRftCaseQuery,
     RootIncidentQuery,
     RootIndicatorQuery,
+    RootThreatActorGroupQuery,
     RootIndividualQuery,
     RootPrivateQuery,
     RootStixCyberObservableQuery,
@@ -111,6 +117,7 @@ import {
     OrderingMode,
     StixCoreRelationshipAddInput,
     StixRefRelationshipAddInput,
+    ThreatGroupAddInput,
 } from "./graphql/types.js";
 import { OpenCTIStream, OpenCTIStreamOptions } from "./sync.js";
 import {
@@ -126,6 +133,7 @@ import {
     ImportContentQueryResult,
     Incident,
     Indicator,
+    ThreatGroup,
     Individual,
     Label,
     Me,
@@ -175,6 +183,11 @@ export class OpenCTIClient {
 
                     NoteLine_node,
                     StixCoreObjectOrStixCoreRelationshipNoteCard_node,
+
+                    ThreatActorGroup_ThreatActorGroup,
+                    ThreatActorGroupKnowledge_ThreatActorGroup,
+                    ThreatActorGroupDetails_ThreatActorGroup,
+                    ThreatActorGroupLocations_locations,
 
                     Individual_individual,
                     IndividualDetails_individual,
@@ -705,6 +718,28 @@ export class OpenCTIClient {
     }
 
     //#region identities
+    public async createThreatGroup(input: ThreatGroupAddInput): Promise<ThreatGroup> {
+        const result = await this.client.mutate<{ threatActorGroupAdd: ThreatGroup }>({
+            mutation: ThreatGroupCreationMutation,
+            variables: {
+                input: input,
+            },
+        });
+
+        return this.assertMutateResult(result).threatActorGroupAdd;
+    }
+
+    public async getThreatGroup(id: StixRef): Promise<ThreatGroup | null> {
+        const result = await this.client.query<{ threatActorGroup: ThreatGroup | null }>({
+            query: RootThreatActorGroupQuery,
+            variables: {
+                id: id,
+            },
+        });
+
+        return this.assertQueryResult(result).threatActorGroup;
+    }
+
     public async getIndividual(id: StixRef): Promise<Individual | null> {
         const result = await this.client.query<{ individual: Individual | null }>({
             query: RootIndividualQuery,

--- a/src/opencti.ts
+++ b/src/opencti.ts
@@ -72,6 +72,7 @@ import {
     IndicatorObservablePopoverDeletionMutation,
     IndicatorPopoverDeletionMutation,
     ThreatGroupCreationMutation,
+    ThreatActorGroupPopoverDeletionMutation,
     IndividualCreationMutation,
     IndividualPopoverDeletionMutation,
     LabelsQuerySearchQuery,
@@ -738,6 +739,17 @@ export class OpenCTIClient {
         });
 
         return this.assertQueryResult(result).threatActorGroup;
+    }
+
+    public async deleteThreatGroup(id: StixRef): Promise<StixRef> {
+        const result = await this.client.mutate<{ threatActorGroupEdit: { delete: StixRef } }>({
+            mutation: ThreatActorGroupPopoverDeletionMutation,
+            variables: {
+                id: id,
+            },
+        });
+
+        return this.assertMutateResult(result).threatActorGroupEdit.delete;
     }
 
     public async getIndividual(id: StixRef): Promise<Individual | null> {

--- a/src/stix/identifiers.ts
+++ b/src/stix/identifiers.ts
@@ -12,6 +12,12 @@ export const generateRequestForTakedownId = (props: Any<{ name: string; created:
     });
 };
 
+export const generateThreatActorGroupId = (props: Any<{ name: string; }>): Identifier<"threat-actor"> => {
+    return generateDeterministicId("threat-actor", {
+        name: normalizeName(props.name),
+    });
+};
+
 export const generateIdentityId = (
     props: Any<{ name: string; identity_class: IdentityClassOv }>,
 ): Identifier<"identity"> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,19 @@ export type ThreatGroup = {
     threat_actor_types: ThreatActorTypes[]
 };
 
+export type ThreatIndividual = {
+    id: string;
+    standard_id: Identifier;
+    entity_type: "Threat-Actor-Individual";
+
+    name: string;
+    description: string;
+    confidence: number;
+    objectMarking: Marking[];
+    objectLabel: Label[];
+    threat_actor_types: ThreatActorTypes[]
+};
+
 export type Individual = {
     id: string;
     standard_id: Identifier;

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,18 @@ export type Profile = {
     };
 };
 
+export type ThreatGroup = {
+    id: string;
+    standard_id: Identifier;
+    entity_type: "Threat-Actor-Group";
+
+    name: string;
+    description: string;
+    confidence: number;
+    objectMarking: Marking[];
+    objectLabel: Label[];
+};
+
 export type Individual = {
     id: string;
     standard_id: Identifier;

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,21 @@ export type Profile = {
     };
 };
 
+export enum ThreatActorTypes {
+    ACTIVIST = "activist",
+    COMPETITOR = "competitor",
+    CRIME_SYNDICATE = "crime-syndicate",
+    CRIMINAL = "criminal",
+    HACKER = "hacker",
+    INSIDER_ACCIDENTAL = "insider-accidental",
+    INSIDER_DISGRUNTED = "insider-disgruntled",
+    NATION_STATE = "nation-state",
+    SENSATIONALIST = "sensationalist",
+    SPY = "spy",
+    TERRORIST = "terrorist",
+    UNKNOWN = "unknown"
+};
+
 export type ThreatGroup = {
     id: string;
     standard_id: Identifier;
@@ -156,6 +171,7 @@ export type ThreatGroup = {
     confidence: number;
     objectMarking: Marking[];
     objectLabel: Label[];
+    threat_actor_types: ThreatActorTypes[]
 };
 
 export type Individual = {

--- a/test/.t.env.example
+++ b/test/.t.env.example
@@ -1,0 +1,2 @@
+OPENCTI_URL=https://sealisac.dev
+OPENCTI_API_KEY="XXXXXXXXXXXXXXX"

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,14 +8,13 @@ import { OpenCTIClient } from "../src/index.js";
 import {
     generateCryptocurrencyWalletObservableId,
     generateIdentityId,
-    generateThreatActorGroupId,
     generateIndicatorId,
     generateLabelId,
 } from "../src/stix/identifiers.js";
 import { EXTENSION_DEFINITION_OCTI_SDO, MARKING_TLP_CLEAR, MARKING_TLP_RED } from "../src/stix/constants.js";
 import { StixRef } from "../src/types.js";
 
-const client = new OpenCTIClient("https://sealisac.dev", process.env.SEAL_ISAC_API_KEY!);
+const client = new OpenCTIClient(process.env.OPENCTI_URL!, process.env.OPENCTI_API_KEY!);
 
 describe("Observables", () => {
     describe("Domain-Name", () => {
@@ -269,38 +268,6 @@ describe("Identities", () => {
         assert.equal(id, expectedIndividual.standard_id);
 
         await rejects(client.deleteIndividual(expectedIndividual.standard_id));
-    });
-});
-
-describe("Threat Actor Groups", () => {
-    const name = v4();
-
-    const expectedThreatGroup = {
-        name: name,
-        description: v4(),
-        confidence: 100,
-        objectMarking: [MARKING_TLP_RED],
-
-        standard_id: "",
-    };
-    expectedThreatGroup.standard_id = generateThreatActorGroupId({ name: name });
-
-    it("should create a threat actor group", async () => {
-        const existingGroup = await client.getThreatGroup(expectedThreatGroup.standard_id);
-        assert.equal(existingGroup, null);
-
-        const group = await client.createThreatGroup({
-            name: expectedThreatGroup.name,
-            description: expectedThreatGroup.description,
-            confidence: expectedThreatGroup.confidence,
-            objectMarking: expectedThreatGroup.objectMarking,
-        });
-
-        assert.equal(group.standard_id, expectedThreatGroup.standard_id);
-        assert.equal(group.name, expectedThreatGroup.name);
-        assert.equal(group.description, expectedThreatGroup.description);
-        assert.equal(group.objectMarking.length, 1);
-        assert.equal(group.objectMarking[0].standard_id, expectedThreatGroup.objectMarking[0]);
     });
 });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,6 +8,7 @@ import { OpenCTIClient } from "../src/index.js";
 import {
     generateCryptocurrencyWalletObservableId,
     generateIdentityId,
+    generateThreatActorGroupId,
     generateIndicatorId,
     generateLabelId,
 } from "../src/stix/identifiers.js";
@@ -268,6 +269,38 @@ describe("Identities", () => {
         assert.equal(id, expectedIndividual.standard_id);
 
         await rejects(client.deleteIndividual(expectedIndividual.standard_id));
+    });
+});
+
+describe("Threat Actor Groups", () => {
+    const name = v4();
+
+    const expectedThreatGroup = {
+        name: name,
+        description: v4(),
+        confidence: 100,
+        objectMarking: [MARKING_TLP_RED],
+
+        standard_id: "",
+    };
+    expectedThreatGroup.standard_id = generateThreatActorGroupId({ name: name });
+
+    it("should create a threat actor group", async () => {
+        const existingGroup = await client.getThreatGroup(expectedThreatGroup.standard_id);
+        assert.equal(existingGroup, null);
+
+        const group = await client.createThreatGroup({
+            name: expectedThreatGroup.name,
+            description: expectedThreatGroup.description,
+            confidence: expectedThreatGroup.confidence,
+            objectMarking: expectedThreatGroup.objectMarking,
+        });
+
+        assert.equal(group.standard_id, expectedThreatGroup.standard_id);
+        assert.equal(group.name, expectedThreatGroup.name);
+        assert.equal(group.description, expectedThreatGroup.description);
+        assert.equal(group.objectMarking.length, 1);
+        assert.equal(group.objectMarking[0].standard_id, expectedThreatGroup.objectMarking[0]);
     });
 });
 


### PR DESCRIPTION
Adds the ability to create threat actor groups via the GraphQL API. The plan of usage (from me, anyway) is to build out more blockchain-based connectors using `@security-alliance/seal-isac-sdk.js`  so we can get more granular with DaaS (TA groups) and their affiliates (individuals)

# Rationale

-  **Threat Actor Groups:** This will be used to document organised threat groups, such as DaaS vendors. 
   - Created with `createThreatGroup()`
  
-  **Threat Actor Individuals:** This will be used to document individuals affiliated with a known group, such as a client of a DaaS. 
   - Created with `createThreatIndividual()`
   
- **Individual:** This will be used to document entities that are/could be targeted by threat actors. Having them as individuals will allow us to assign them in victimology relationships to an attack/campaign. 
   - Created with `createIndividual()`